### PR TITLE
Implement SPI clean exit, made available from the new dmdreader version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -257,7 +257,7 @@ extra_scripts = pre:scripts/stage_fs_data.py
 lib_deps =
     thomasfredericks/Bounce2
     https://github.com/PPUC/zedmd-pico-drivers#5adc6bf029df386722dd84da3e5e0395d4fd47a2
-    https://github.com/PPUC/dmdreader#79f6d8ec15ed2f61b5b3989b99f52679a359e2e2
+    https://github.com/PPUC/dmdreader#9a334ed74662d9d2e3b94b60db1a59c447139c07
 lib_ignore =
     WiFi
     AsyncUDP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2334,7 +2334,7 @@ void loop1() {
     return;
 
   } else if (!transport->isLoopback()) {
-    dmdreader_spi_send();
+    dmdreader_spi_send(!spiTransport->isActive());
     tight_loop_contents();
 
   } else {


### PR DESCRIPTION
- Passes whether SPI is active into the dmdreader_spi_send function. If the device is restarting, SPI will be set to inactive, resulting in true being passed to then trigger a clean SPI exit.